### PR TITLE
feat: swagger 는 spring security 로그인 과정 없이도 입장가능하도록 변경

### DIFF
--- a/src/main/java/com/app/api/core/config/WebSecurityConfig.java
+++ b/src/main/java/com/app/api/core/config/WebSecurityConfig.java
@@ -5,7 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -19,6 +22,11 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class WebSecurityConfig {
 
     private final JwtTokenFilter jwtTokenFilter;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().antMatchers("/v2/api-docs", "/swagger*/**", "/webjars/**", "/test_db/**");
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {


### PR DESCRIPTION
spring security 설정 추가에 따라 현재 모든 페이지가 로그인 이후에 들어갈 수 있습니다.

swagger의 경우 로그인이 필요하지 않으므로 front-end 에서 자유롭게 볼 수 있도록 인증과정을 제외하는 설정을 추가했습니다