### PR TITLE
fix: 유저 챌린지 일별 조회 시 인증정보도 같이 보여지게 반영

### DIFF
--- a/src/main/java/com/app/api/challenge/dto/UserChallengeDayListDto.java
+++ b/src/main/java/com/app/api/challenge/dto/UserChallengeDayListDto.java
@@ -3,12 +3,10 @@ package com.app.api.challenge.dto;
 import com.app.api.challenge.enums.ChallengeStatus;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.Min;
 import java.time.LocalDateTime;
 
 @Getter
@@ -16,33 +14,52 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class UserChallengeDayListDto {
 
-    @ApiModelProperty(value = "유저 챌린지 ID", example = "1", required = true)
+    @ApiModelProperty(value = "유저 챌린지 ID", example = "1")
     private long id;
 
-    @ApiModelProperty(value = "챌린지 ID", example = "2", required = true)
+    @ApiModelProperty(value = "유저 ID", example = "1")
+    private long userId;
+
+    @ApiModelProperty(value = "챌린지 ID", example = "2")
     private long challengeId;
 
-    @ApiModelProperty(value = "챌린지명", example = "우유 대신 두유 먹기", required = true)
+    @ApiModelProperty(value = "챌린지 날짜", example = "2022-08-30T00:00:00")
+    private LocalDateTime challengeDate;
+
+    @ApiModelProperty(value = "챌린지명", example = "우유 대신 두유 먹기")
     private String name;
 
     @ApiModelProperty(value = "챌린지 이모지", example = "\uD83C\uDF3E")
     private String emoji;
 
-    @ApiModelProperty(value = "챌린지 날짜", example = "2022-08-30T00:00:00", required = true)
-    private LocalDateTime challengeDate;
-
     @ApiModelProperty(value = "챌린지 인증 상태", example = "WAITING")
     private ChallengeStatus verificationStatus;
 
+    @ApiModelProperty(value = "챌린지 인증 날짜", example = "2022-08-30T00:00:00")
+    private LocalDateTime verificationDate;
+
+    @ApiModelProperty(value = "챌린지 인증 메모", example = "챌린지 인증 메모...ㅎㅎ")
+    private String verificationMemo;
+
+    @ApiModelProperty(value = "챌린지 인증 사진", example = "https://...")
+    private String verificationImage;
+
     @QueryProjection
     @Builder
-    public UserChallengeDayListDto(long id, long challengeId, String name, String emoji, LocalDateTime challengeDate, ChallengeStatus verificationStatus) {
+    public UserChallengeDayListDto(
+            long id, long userId, long challengeId, LocalDateTime challengeDate, String name, String emoji,
+            ChallengeStatus verificationStatus, LocalDateTime verificationDate, String verificationMemo,
+            String verificationImage) {
         this.id = id;
+        this.userId = userId;
         this.challengeId = challengeId;
+        this.challengeDate = challengeDate;
         this.name = name;
         this.emoji = emoji;
-        this.challengeDate = challengeDate;
         this.verificationStatus = verificationStatus;
+        this.verificationDate = verificationDate;
+        this.verificationMemo = verificationMemo;
+        this.verificationImage = verificationImage;
     }
 }
 

--- a/src/main/java/com/app/api/challenge/entity/UserChallenge.java
+++ b/src/main/java/com/app/api/challenge/entity/UserChallenge.java
@@ -66,6 +66,7 @@ public class UserChallenge extends BaseTimeEntity {
         }
 
         this.verificationMemo = memo;
+        this.verificationDate = LocalDateTime.now();
     }
 
     public void deleteVerifyUserChallenge() {

--- a/src/main/java/com/app/api/challenge/repository/UserChallengeRepositoryCustomImpl.java
+++ b/src/main/java/com/app/api/challenge/repository/UserChallengeRepositoryCustomImpl.java
@@ -20,11 +20,15 @@ public class UserChallengeRepositoryCustomImpl implements UserChallengeRepositor
     public List<UserChallengeDayListDto> findAllByUserIdAndChallengeDate(Long userId, LocalDateTime challengeDate) {
         return queryFactory.select(new QUserChallengeDayListDto(
                 userChallenge.id,
+                userChallenge.userId,
                 userChallenge.challengeId,
+                userChallenge.challengeDate,
                 challenge.name,
                 challenge.emoji,
-                userChallenge.challengeDate,
-                userChallenge.verificationStatus
+                userChallenge.verificationStatus,
+                userChallenge.verificationDate,
+                userChallenge.verificationMemo,
+                userChallenge.verificationImage
         )).from(userChallenge)
                 .innerJoin(challenge).on(userChallenge.challengeId.eq(challenge.id))
                 .where(userChallenge.userId.eq(userId),

--- a/src/main/java/com/app/api/challenge/service/UserChallengeService.java
+++ b/src/main/java/com/app/api/challenge/service/UserChallengeService.java
@@ -17,7 +17,6 @@ import com.app.api.user.dto.UserDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -39,7 +38,7 @@ public class UserChallengeService {
 
     @Transactional
     public UserChallengeVerifyResponseDto verifyUserChallenge(UserDTO userDTO,
-                                                              @Validated UserChallengeVerifyRegDto userChallengeVerifyRegDto,
+                                                              UserChallengeVerifyRegDto userChallengeVerifyRegDto,
                                                               List<MultipartFile> multipartFileList) {
         // 정책상 이미지 업로드는 1개만 가능
         if (multipartFileList.size() != 1)

--- a/src/main/java/com/app/api/challenge/service/UserChallengeService.java
+++ b/src/main/java/com/app/api/challenge/service/UserChallengeService.java
@@ -17,6 +17,7 @@ import com.app.api.user.dto.UserDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -38,7 +39,7 @@ public class UserChallengeService {
 
     @Transactional
     public UserChallengeVerifyResponseDto verifyUserChallenge(UserDTO userDTO,
-                                                              UserChallengeVerifyRegDto userChallengeVerifyRegDto,
+                                                              @Validated UserChallengeVerifyRegDto userChallengeVerifyRegDto,
                                                               List<MultipartFile> multipartFileList) {
         // 정책상 이미지 업로드는 1개만 가능
         if (multipartFileList.size() != 1)

--- a/src/main/java/com/app/api/user/service/UserService.java
+++ b/src/main/java/com/app/api/user/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
         checkDuplicateNickname(userRegDTO.getNickName());
 
         // 기존 회원가입 여부 확인 - email을 기준
-        userRepository.findByEmail(email).ifPresent(user -> {
+        userRepository.findByAppleIdAndEmail(userRegDTO.getAppleId(), email).ifPresent(user -> {
             throw BizException.withUserMessageKey("exception.user.already.exist").build();
         });
 

--- a/src/main/java/com/app/api/user/service/UserService.java
+++ b/src/main/java/com/app/api/user/service/UserService.java
@@ -51,8 +51,13 @@ public class UserService {
         checkDuplicateNickname(userRegDTO.getNickName());
 
         // 기존 회원가입 여부 확인 - email을 기준
-        userRepository.findByAppleIdAndEmail(userRegDTO.getAppleId(), email).ifPresent(user -> {
-            throw BizException.withUserMessageKey("exception.user.already.exist").build();
+        userRepository.findByEmail(email).ifPresent(user -> {
+            throw BizException.withUserMessageKey("exception.user.email.already.exist").build();
+        });
+
+        // 기존 회원가입 여부 확인 - appleId을 기준
+        userRepository.findByAppleId(userRegDTO.getAppleId()).ifPresent(user -> {
+            throw BizException.withUserMessageKey("exception.user.appleId.already.exist").build();
         });
 
         // save user

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -53,7 +53,8 @@ exception.auth.refreshToken.not.found=refreshToken 정보를 찾을 수 없습�
 
 ##### user
 exception.user.not.found=해당 유저를 찾을 수 없습니다.
-exception.user.already.exist=해당계정은 이미 회원가입되어 있습니다.
+exception.user.email.already.exist=해당계정의 이메일은 이미 회원가입되어 있습니다.
+exception.user.appleId.already.exist=해당계정의 appleId는 이미 회원가입되어 있습니다.
 exception.user.nickName.already.exist=해당 닉네임은 이미 존재합니다. 다른 닉네임을 사용하여 주세요.
 exception.user.role.type.null=계정의 권한정보 값이 없습니다.
 exception.user.create.admin.role=어드민 권한 생성은 진행할 수 없습니다.

--- a/src/test/java/com/app/api/user/service/UserServiceTest.java
+++ b/src/test/java/com/app/api/user/service/UserServiceTest.java
@@ -103,7 +103,7 @@ class UserServiceTest extends BaseTest {
                         userService.signup(userRegDTO);
                         userService.signup(userRegDTO2);
                     },
-                    messageComponent.getMessage("exception.user.already.exist"));
+                    messageComponent.getMessage("exception.user.email.already.exist"));
         }
 
         @Test()


### PR DESCRIPTION
1. 유저 챌린지 일별 조회 시 인증정보도 같이 보여지게 반영
2. 유저 챌린지 인증과정에서 인증 날짜가 입력이 안되는 버그가 잇어서 같이 수정해서 올립니다.