### PR TITLE
fix: refreshToken 재요청은 accessToken 값이 만료되었기 때문에 로그인과 같은 걸로 보고, jwt ac…

### DIFF
--- a/src/main/java/com/app/api/core/config/WebSecurityConfig.java
+++ b/src/main/java/com/app/api/core/config/WebSecurityConfig.java
@@ -5,9 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -42,6 +40,7 @@ public class WebSecurityConfig {
                         .antMatchers(
                                 "/signup",
                                 "/auth/login",
+                                "/auth/refreshToken",
                                 "/check/nick-name"
                         ).permitAll()
                         .antMatchers("/user/**").hasAuthority("USER")


### PR DESCRIPTION
…cessToken 검사를 제외한다.